### PR TITLE
Add `comesFromUI` field to `AdmEvent`

### DIFF
--- a/src/main/scala/com/galois/adapt/ApiJsonProtocol.scala
+++ b/src/main/scala/com/galois/adapt/ApiJsonProtocol.scala
@@ -88,7 +88,7 @@ object ApiJsonProtocol extends SprayJsonSupport with DefaultJsonProtocol {
   implicit val cdmHostIdentifier = jsonFormat2(HostIdentifier.apply)
 
   // ADM nodes
-  implicit val admEvent = jsonFormat(AdmEvent.apply, "originalCdmUuids", "eventType", "earliestTimestampNanos", "latestTimestampNanos", "deviceType", "inputType", "hostName", "provider")
+  implicit val admEvent = jsonFormat(AdmEvent.apply, "originalCdmUuids", "eventType", "earliestTimestampNanos", "latestTimestampNanos", "comesFromUI", "hostName", "provider")
   implicit val admSubject = jsonFormat(AdmSubject.apply, "originalCdmUuids", "subjectTypes", "cid", "startTimestampNanos", "hostName", "provider")
   implicit val admPathNode = jsonFormat(AdmPathNode.apply, "path", "provider")
   implicit val admFileObject = jsonFormat(AdmFileObject.apply, "originalCdmUuids", "fileObjectType", "size", "hostName", "provider")

--- a/src/main/scala/com/galois/adapt/PpmFlowComponents.scala
+++ b/src/main/scala/com/galois/adapt/PpmFlowComponents.scala
@@ -130,7 +130,7 @@ object PpmFlowComponents {
                 val hostName = Try(p.asInstanceOf[AdmSubject].hostName).getOrElse("")
                 val admParentTime = Try(p.asInstanceOf[AdmSubject].startTimestampNanos).getOrElse(0L)
                 val admChildTime = Try(c.asInstanceOf[AdmSubject].startTimestampNanos).getOrElse(0L)
-                (AdmEvent(Seq.empty, PSEUDO_EVENT_PARENT_SUBJECT, admParentTime, admChildTime, None, None, hostName, provider), c, c.uuid, p, p.uuid)
+                (AdmEvent(Seq.empty, PSEUDO_EVENT_PARENT_SUBJECT, admParentTime, admChildTime, false, hostName, provider), c, c.uuid, p, p.uuid)
               }
             }
           )

--- a/src/main/scala/com/galois/adapt/adm/ERRules.scala
+++ b/src/main/scala/com/galois/adapt/adm/ERRules.scala
@@ -151,8 +151,11 @@ object ERRules {
         eventType = e.eventType,
         earliestTimestampNanos = e.timestampNanos,
         latestTimestampNanos = e.timestampNanos,
-        deviceType = e.properties.flatMap(_.get("deviceType")),
-        inputType = e.properties.flatMap(_.get("inputType")),
+        comesFromUI = List(
+          e.properties.flatMap(_.get("deviceType")).fold(false)(dt => dt == "keyboard" || dt == "mouse"),  // 5D
+          e.names.contains("MouseDownPositionInfo") || e.names.contains("KeyBoardInfo"),                   // Marple
+          e.names.contains("UI_EVENT")                                                                     // Theia
+        ).exists(identity),
         hostName,
         provider
       )

--- a/src/main/scala/com/galois/adapt/adm/package.scala
+++ b/src/main/scala/com/galois/adapt/adm/package.scala
@@ -147,10 +147,13 @@ package object adm {
     earliestTimestampNanos: Long,
     latestTimestampNanos: Long,
 
-    // 5D specific
-    // See <https://git.tc.bbn.com/tc-all/cdm-docs/blob/master/ta1-fivedirections/operations/user_interaction.md>
-    deviceType: Option[String],
-    inputType: Option[String],
+    /* Comes from sort of UI event
+     *
+     *   - 5D:     does properties map at 'deviceType' contain 'keyboard'/'mouse'
+     *   - Marple: does the `name` array contain `MouseDownPositionInfo`/`KeyBoardInfo`?
+     *   - Theia:  does the `name` array contain `UI_EVENT`
+     */
+    comesFromUI: Boolean,
 
     hostName: HostName,
     provider: String
@@ -165,15 +168,17 @@ package object adm {
       "originalCdmUuids" -> originalCdmUuids.map(_.uuid).toList.sorted.mkString(";"),
       "eventType" -> eventType.toString,
       "earliestTimestampNanos" -> earliestTimestampNanos,
-      "latestTimestampNanos" -> latestTimestampNanos
-    )  ++ (if (provider.isEmpty) Nil else List("provider" -> provider)) ++ {if (deviceType == None) Nil else List("deviceType" -> deviceType.get)} ++ (if (inputType == None) Nil else List("inputType" -> inputType.get))
+      "latestTimestampNanos" -> latestTimestampNanos,
+      "comesFromUI" -> comesFromUI
+    )  ++ (if (provider.isEmpty) Nil else List("provider" -> provider))
 
     def toMap = Map(
       "originalCdmUuids" -> originalCdmUuids.map(_.uuid).toList.sorted.mkString(";"),
       "eventType" -> eventType.toString,
       "earliestTimestampNanos" -> earliestTimestampNanos,
       "latestTimestampNanos" -> latestTimestampNanos,
-      "provider" -> provider
+      "provider" -> provider,
+      "comesFromUI" -> comesFromUI
     )
   }
 


### PR DESCRIPTION
This indicates that the event originated from some sort of user interaction. It can be filled in for 5D, Marple, and Theia. I additionally removed the 5D specific `inputType`/`deviceType` fields since `comesFromUI` is probably all we need (and I want to avoid a proliferation of provider-specific fields in `AdmEvent`).